### PR TITLE
feat(ui): sotd card molecule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
 bun dev
 ```
 
@@ -20,17 +14,3 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,101 +1,25 @@
-import Image from "next/image";
+import { SotdCard } from "@/components/molecules/sotd-card";
+import { default as track01 } from "@/data/mock/tracks/01.json";
+import { default as track02 } from "@/data/mock/tracks/02.json";
+import { default as track03 } from "@/data/mock/tracks/03.json";
+import { default as track04 } from "@/data/mock/tracks/04.json";
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
+  const tracks = [track01, track02, track03, track04];
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+  return (
+    <div className="flex flex-col gap-4 mx-8 my-6">
+      {tracks.map((track) => (
+        <SotdCard
+          key={track.id}
+          albumCoverSrc={track.album.images[0].url}
+          trackName={track.name}
+          trackAlbumName={track.album.name}
+          artist={track.artists
+            .map((artist: { name: string }) => artist.name)
+            .join(", ")}
+        />
+      ))}
     </div>
   );
 }

--- a/components/molecules/sotd-card.tsx
+++ b/components/molecules/sotd-card.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+
+import { AspectRatio } from "@/components/atoms/aspect-ratio";
+
+export const SotdCard = ({
+  albumCoverSrc,
+  trackName,
+  trackAlbumName,
+  artist,
+}: {
+  albumCoverSrc: string;
+  trackName: string;
+  trackAlbumName: string;
+  artist: string;
+}) => {
+  return (
+    <div className="flex gap-4 items-center">
+      <div className="w-[96px]">
+        <AspectRatio ratio={1}>
+          <Image
+            fill
+            // API: https://developer.spotify.com/documentation/web-api/reference/get-track
+            // from `album.images[0].url`
+            src={albumCoverSrc}
+            alt="album cover"
+            className="object-cover rounded"
+          />
+        </AspectRatio>
+      </div>
+
+      <div className="flex-1">
+        <h2 className="text-2xl font-bold">{trackName}</h2>
+        <p className="text-sm text-gray-500">{trackAlbumName}</p>
+        <p className="text-lg">{artist}</p>
+      </div>
+    </div>
+  );
+};

--- a/data/mock/tracks/01.json
+++ b/data/mock/tracks/01.json
@@ -1,0 +1,77 @@
+{
+  "album": {
+    "album_type": "album",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/7cYEt1pqMgXJdq00hAwVpT"
+        },
+        "href": "https://api.spotify.com/v1/artists/7cYEt1pqMgXJdq00hAwVpT",
+        "id": "7cYEt1pqMgXJdq00hAwVpT",
+        "name": "Chase Atlantic",
+        "type": "artist",
+        "uri": "spotify:artist:7cYEt1pqMgXJdq00hAwVpT"
+      }
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/6fCGW5OWBTrtesYXjEze3h"
+    },
+    "href": "https://api.spotify.com/v1/albums/6fCGW5OWBTrtesYXjEze3h",
+    "id": "6fCGW5OWBTrtesYXjEze3h",
+    "images": [
+      {
+        "url": "https://i.scdn.co/image/ab67616d0000b273dafbcc0d1c4251faa086b9ef",
+        "width": 640,
+        "height": 640
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d00001e02dafbcc0d1c4251faa086b9ef",
+        "width": 300,
+        "height": 300
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d00004851dafbcc0d1c4251faa086b9ef",
+        "width": 64,
+        "height": 64
+      }
+    ],
+    "is_playable": true,
+    "name": "LOST IN HEAVEN",
+    "release_date": "2024-11-01",
+    "release_date_precision": "day",
+    "total_tracks": 13,
+    "type": "album",
+    "uri": "spotify:album:6fCGW5OWBTrtesYXjEze3h"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/7cYEt1pqMgXJdq00hAwVpT"
+      },
+      "href": "https://api.spotify.com/v1/artists/7cYEt1pqMgXJdq00hAwVpT",
+      "id": "7cYEt1pqMgXJdq00hAwVpT",
+      "name": "Chase Atlantic",
+      "type": "artist",
+      "uri": "spotify:artist:7cYEt1pqMgXJdq00hAwVpT"
+    }
+  ],
+  "disc_number": 1,
+  "duration_ms": 206815,
+  "explicit": true,
+  "external_ids": {
+    "isrc": "US5262426872"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/0BmRj1LXJGPAox0pl3rMbc"
+  },
+  "href": "https://api.spotify.com/v1/tracks/0BmRj1LXJGPAox0pl3rMbc",
+  "id": "0BmRj1LXJGPAox0pl3rMbc",
+  "is_local": false,
+  "is_playable": true,
+  "name": "DIE FOR ME",
+  "popularity": 62,
+  "preview_url": null,
+  "track_number": 2,
+  "type": "track",
+  "uri": "spotify:track:0BmRj1LXJGPAox0pl3rMbc"
+}

--- a/data/mock/tracks/02.json
+++ b/data/mock/tracks/02.json
@@ -1,0 +1,87 @@
+{
+  "album": {
+    "album_type": "album",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/57vWImR43h4CaDao012Ofp"
+        },
+        "href": "https://api.spotify.com/v1/artists/57vWImR43h4CaDao012Ofp",
+        "id": "57vWImR43h4CaDao012Ofp",
+        "name": "Steve Lacy",
+        "type": "artist",
+        "uri": "spotify:artist:57vWImR43h4CaDao012Ofp"
+      }
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/4tRInpsZkScWnp3UWcdLTq"
+    },
+    "href": "https://api.spotify.com/v1/albums/4tRInpsZkScWnp3UWcdLTq",
+    "id": "4tRInpsZkScWnp3UWcdLTq",
+    "images": [
+      {
+        "url": "https://i.scdn.co/image/ab67616d0000b2735cc2b8beee1bae039987f2d2",
+        "width": 640,
+        "height": 640
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d00001e025cc2b8beee1bae039987f2d2",
+        "width": 300,
+        "height": 300
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d000048515cc2b8beee1bae039987f2d2",
+        "width": 64,
+        "height": 64
+      }
+    ],
+    "is_playable": true,
+    "name": "Gemini Rights",
+    "release_date": "2022-07-14",
+    "release_date_precision": "day",
+    "total_tracks": 10,
+    "type": "album",
+    "uri": "spotify:album:4tRInpsZkScWnp3UWcdLTq"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/57vWImR43h4CaDao012Ofp"
+      },
+      "href": "https://api.spotify.com/v1/artists/57vWImR43h4CaDao012Ofp",
+      "id": "57vWImR43h4CaDao012Ofp",
+      "name": "Steve Lacy",
+      "type": "artist",
+      "uri": "spotify:artist:57vWImR43h4CaDao012Ofp"
+    },
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/6trIghKwHRUyxwvm66HLHH"
+      },
+      "href": "https://api.spotify.com/v1/artists/6trIghKwHRUyxwvm66HLHH",
+      "id": "6trIghKwHRUyxwvm66HLHH",
+      "name": "Fousheé",
+      "type": "artist",
+      "uri": "spotify:artist:6trIghKwHRUyxwvm66HLHH"
+    }
+  ],
+  "disc_number": 1,
+  "duration_ms": 293426,
+  "explicit": false,
+  "external_ids": {
+    "isrc": "USRC12202291"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/14Q7Qja4PJwjMsKdBZcnww"
+  },
+  "href": "https://api.spotify.com/v1/tracks/14Q7Qja4PJwjMsKdBZcnww",
+  "id": "14Q7Qja4PJwjMsKdBZcnww",
+  "is_local": false,
+  "is_playable": true,
+  "name": "Sunshine (feat. Fousheé)",
+  "popularity": 59,
+  "preview_url": null,
+  "track_number": 9,
+  "type": "track",
+  "uri": "spotify:track:14Q7Qja4PJwjMsKdBZcnww"
+}

--- a/data/mock/tracks/03.json
+++ b/data/mock/tracks/03.json
@@ -1,0 +1,77 @@
+{
+  "album": {
+    "album_type": "album",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/0fTSzq9jAh4c36UVb4V7CB"
+        },
+        "href": "https://api.spotify.com/v1/artists/0fTSzq9jAh4c36UVb4V7CB",
+        "id": "0fTSzq9jAh4c36UVb4V7CB",
+        "name": "Alex Warren",
+        "type": "artist",
+        "uri": "spotify:artist:0fTSzq9jAh4c36UVb4V7CB"
+      }
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/1cVpXZnVWHTDUuY8kW6x8M"
+    },
+    "href": "https://api.spotify.com/v1/albums/1cVpXZnVWHTDUuY8kW6x8M",
+    "id": "1cVpXZnVWHTDUuY8kW6x8M",
+    "images": [
+      {
+        "url": "https://i.scdn.co/image/ab67616d0000b2736a794c49d6df89ec45d5b925",
+        "width": 640,
+        "height": 640
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d00001e026a794c49d6df89ec45d5b925",
+        "width": 300,
+        "height": 300
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d000048516a794c49d6df89ec45d5b925",
+        "width": 64,
+        "height": 64
+      }
+    ],
+    "is_playable": true,
+    "name": "You'll Be Alright, Kid (Chapter 1)",
+    "release_date": "2024-09-27",
+    "release_date_precision": "day",
+    "total_tracks": 10,
+    "type": "album",
+    "uri": "spotify:album:1cVpXZnVWHTDUuY8kW6x8M"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/0fTSzq9jAh4c36UVb4V7CB"
+      },
+      "href": "https://api.spotify.com/v1/artists/0fTSzq9jAh4c36UVb4V7CB",
+      "id": "0fTSzq9jAh4c36UVb4V7CB",
+      "name": "Alex Warren",
+      "type": "artist",
+      "uri": "spotify:artist:0fTSzq9jAh4c36UVb4V7CB"
+    }
+  ],
+  "disc_number": 1,
+  "duration_ms": 176178,
+  "explicit": false,
+  "external_ids": {
+    "isrc": "USAT22314248"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/2XxpxQ1PeQhPMVikjKnmJy"
+  },
+  "href": "https://api.spotify.com/v1/tracks/2XxpxQ1PeQhPMVikjKnmJy",
+  "id": "2XxpxQ1PeQhPMVikjKnmJy",
+  "is_local": false,
+  "is_playable": true,
+  "name": "Before You Leave Me",
+  "popularity": 76,
+  "preview_url": null,
+  "track_number": 6,
+  "type": "track",
+  "uri": "spotify:track:2XxpxQ1PeQhPMVikjKnmJy"
+}

--- a/data/mock/tracks/04.json
+++ b/data/mock/tracks/04.json
@@ -1,0 +1,87 @@
+{
+  "album": {
+    "album_type": "album",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/0hCNtLu0JehylgoiP8L4Gh"
+        },
+        "href": "https://api.spotify.com/v1/artists/0hCNtLu0JehylgoiP8L4Gh",
+        "id": "0hCNtLu0JehylgoiP8L4Gh",
+        "name": "Nicki Minaj",
+        "type": "artist",
+        "uri": "spotify:artist:0hCNtLu0JehylgoiP8L4Gh"
+      }
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/6fABwONLawdFjkDpLx41j8"
+    },
+    "href": "https://api.spotify.com/v1/albums/6fABwONLawdFjkDpLx41j8",
+    "id": "6fABwONLawdFjkDpLx41j8",
+    "images": [
+      {
+        "url": "https://i.scdn.co/image/ab67616d0000b2734f0aae4e435a794e0e24d115",
+        "width": 640,
+        "height": 640
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d00001e024f0aae4e435a794e0e24d115",
+        "width": 300,
+        "height": 300
+      },
+      {
+        "url": "https://i.scdn.co/image/ab67616d000048514f0aae4e435a794e0e24d115",
+        "width": 64,
+        "height": 64
+      }
+    ],
+    "is_playable": true,
+    "name": "Pink Friday ... Roman Reloaded (Deluxe)",
+    "release_date": "2012-01-01",
+    "release_date_precision": "day",
+    "total_tracks": 21,
+    "type": "album",
+    "uri": "spotify:album:6fABwONLawdFjkDpLx41j8"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/0hCNtLu0JehylgoiP8L4Gh"
+      },
+      "href": "https://api.spotify.com/v1/artists/0hCNtLu0JehylgoiP8L4Gh",
+      "id": "0hCNtLu0JehylgoiP8L4Gh",
+      "name": "Nicki Minaj",
+      "type": "artist",
+      "uri": "spotify:artist:0hCNtLu0JehylgoiP8L4Gh"
+    },
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/4L3GTE04bW5N7azA9QPhjA"
+      },
+      "href": "https://api.spotify.com/v1/artists/4L3GTE04bW5N7azA9QPhjA",
+      "id": "4L3GTE04bW5N7azA9QPhjA",
+      "name": "Beenie Man",
+      "type": "artist",
+      "uri": "spotify:artist:4L3GTE04bW5N7azA9QPhjA"
+    }
+  ],
+  "disc_number": 1,
+  "duration_ms": 279586,
+  "explicit": true,
+  "external_ids": {
+    "isrc": "USCM51200123"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/1lMpLdgKrjP9FEn35JY1E3"
+  },
+  "href": "https://api.spotify.com/v1/tracks/1lMpLdgKrjP9FEn35JY1E3",
+  "id": "1lMpLdgKrjP9FEn35JY1E3",
+  "is_local": false,
+  "is_playable": true,
+  "name": "Gun Shot",
+  "popularity": 29,
+  "preview_url": null,
+  "track_number": 18,
+  "type": "track",
+  "uri": "spotify:track:1lMpLdgKrjP9FEn35JY1E3"
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,17 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.scdn.co",
+        port: "",
+        pathname: "/image/**",
+        search: "",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
reopened to deploy on vercel instead. see #2 

## Changes

- add example tracks
- add `<SotdSard/>` molecule component
- allow spotify cdn domain `i.scdn.co` for `<Image/>` components on nextconfig

## Preview 

![image](https://github.com/user-attachments/assets/fa75691b-f551-4b06-8c4f-e2b8333c7788)
![image](https://github.com/user-attachments/assets/8d9972b8-467a-46d4-9973-5dcb7252331e)
![image](https://github.com/user-attachments/assets/cd0ebf78-9feb-4020-9c93-9d192e56d2d5)
